### PR TITLE
More lenient matches for GitHub and Azure DevOps urls

### DIFF
--- a/src/providers/azureDevOpsUrlProvider.ts
+++ b/src/providers/azureDevOpsUrlProvider.ts
@@ -4,7 +4,7 @@ export default class AzureDevOpsUrlProvider implements urlProviderBase {
   }
 
   isMatch(remoteUrl: string): boolean {
-    return remoteUrl.startsWith('https://dev.azure.com/')
+    return remoteUrl.includes('dev.azure.com/')
   }
 
   buildUrl(remoteUrl: string, filePath: string, branchName : string, startLineNumber?: number, startColumnNumber?: number, endLineNumber?: number, endColumnNumber?: number): string {

--- a/src/providers/githubUrlProvider.ts
+++ b/src/providers/githubUrlProvider.ts
@@ -4,7 +4,7 @@ export default class GitHubUrlProvider implements urlProviderBase {
   }
 
   isMatch(remoteUrl: string): boolean {
-    return remoteUrl.startsWith('https://github.com/')
+    return remoteUrl.includes('github.com/')
   }
 
   buildUrl(remoteUrl: string, filePath: string, branchName : string, startLineNumber?: number, startColumnNumber?: number, endLineNumber?: number, endColumnNumber?: number): string {


### PR DESCRIPTION
Not a final implementation (which will probably match with regex), but updates GitHub and Azure DevOps url providers to use `.includes()` instead of `.startsWith()`
Closes #3